### PR TITLE
Do not allow Python 3.7 to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ matrix:
     - python: "3.7"
       dist: xenial  # See https://github.com/travis-ci/travis-ci/issues/9069
       sudo: true    # See https://github.com/travis-ci/travis-ci/issues/9069
-  allow_failures:
-    - python: "3.7"
 before_install:
   - export BOTO_CONFIG=/dev/null  # See https://github.com/travis-ci/travis-ci/issues/7940
 script:


### PR DESCRIPTION
Python 3.7 has been released for a while and is now officially supported in Xenial builds on Travis (https://blog.travis-ci.com/2018-11-08-xenial-release).

Also, our Python 3.7 builds have been working smoothly, so it's time to officially support them.