### PR TITLE
Revert "Force sphinx-autodoc-typehints 1.4.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ pytest-cov
 python-coveralls
 mypy
 sphinx
-sphinx-autodoc-typehints<1.5
+sphinx-autodoc-typehints


### PR DESCRIPTION
This reverts commit e572d0ee6dd410997669c6396107f2c69071fcf9.

Reason for revert: fixed upstream by
137e2d54b75a687020ae2161d007ecbe54f59e85.