### PR TITLE
Add filtering for acronyms in expansions

### DIFF
--- a/acres/rater/full.py
+++ b/acres/rater/full.py
@@ -1,6 +1,7 @@
 """
 Rating submodule for full form checks.
 """
+from acres.util import acronym as acro_util
 from acres.util import functions
 
 
@@ -55,6 +56,19 @@ def _has_capitals(full: str) -> bool:
     return True
 
 
+def _contain_acronym(full: str) -> bool:
+    """
+
+    :param full:
+    :return:
+    """
+    words = full.split()
+    for word in words:
+        if acro_util.is_acronym(word):
+            return True
+    return False
+
+
 def _compute_full_valid(full: str) -> int:
     """
     [For internal use only] Compute all checks on full forms.
@@ -76,6 +90,9 @@ def _compute_full_valid(full: str) -> int:
     # A valid expansion of a german acronym would require at least one noun, which is capitalized.
     if not _has_capitals(full):
         ret += 8
+
+    if _contain_acronym(full):
+        ret += 16
 
     return ret
 

--- a/tests/rater/test_full.py
+++ b/tests/rater/test_full.py
@@ -1,6 +1,16 @@
 from acres.rater import full
 
 
+def test__contain_acronym():
+    # Baseline
+    assert not full._contain_acronym("Elektrokardiogramm")
+    assert full._contain_acronym("VSM Bypass")
+    assert full._contain_acronym("Gamma GT")
+
+    # Only acronym
+    assert full._contain_acronym("EKG")
+
+
 def test__compute_full_valid():
     # Full form has parenthesis
     assert 1 == full._compute_full_valid("Abcde(fghi")
@@ -13,3 +23,6 @@ def test__compute_full_valid():
 
     # Full form has no capitals
     assert 8 == full._compute_full_valid("ambulanz")
+
+    # Full form has no capitals
+    assert 16 == full._compute_full_valid("VSM Bypass")


### PR DESCRIPTION
This improves metrics for all methods except word2vec, which had no change.

This fixes #95.