### PR TITLE
Remove NLTK tokenizer

### DIFF
--- a/acres/util/text.py
+++ b/acres/util/text.py
@@ -4,12 +4,8 @@ Utility functions related to text processing.
 import re
 import string
 
-import nltk
-
 from acres import constants
 from acres.preprocess import resource_factory
-
-nltk.download('punkt')
 
 
 def fix_line_endings(long_text: str, char_ngram_length: int = 8,
@@ -216,17 +212,6 @@ def clean_whitespaces(whitespaced: str) -> str:
     :return:
     """
     return remove_duplicated_whitespaces(whitespaced).strip()
-
-
-def tokenize(text: str) -> str:
-    """
-    Tokenizes a given text.
-
-    :param text:
-    :return:
-    """
-    # XXX german-only
-    return " ".join(nltk.word_tokenize(text, "german"))
 
 
 def clean(text: str, preserve_linebreaks: bool = False) -> str:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 gensim
 requests
 html2text
-nltk
 python-Levenshtein
 
 # jupyter notebooks

--- a/tests/util/test_text.py
+++ b/tests/util/test_text.py
@@ -50,12 +50,6 @@ def test_remove_duplicated_whitespaces():
     assert expected == actual
 
 
-def test_tokenize():
-    expected = "SB und LAHB , ¶ QRS-Verbreiterung auf ÐÐÐmsec. , QTC ÐÐÐmsec. ,"
-    input_text = "SB und LAHB, ¶ QRS-Verbreiterung auf ÐÐÐmsec., QTC ÐÐÐmsec.,"
-    assert expected == text.tokenize(input_text)
-
-
 def test_clean():
     input_text = "SB und LAHB, ¶ QRS-Verbreiterung auf ÐÐÐmsec., QTC ÐÐÐmsec.,"
 


### PR DESCRIPTION
The NLTK tokenizer was an old experiment that led to an 8% drop in F1 an so it is currently not used in the codebase.

It is also tricky to maintain, since NLTK data is not available behind some proxies and so a manual installation may be required in a domain-restricted machine.

KISS and remove it. :)