### PR TITLE
Make number of `fastNgram` partitions flexible

### DIFF
--- a/acres/fastngram/fastngram.py
+++ b/acres/fastngram/fastngram.py
@@ -11,11 +11,14 @@ import acres.util.acronym
 from acres.model import topic_list
 from acres.preprocess import resource_factory
 from acres.util import functions
+from acres.util.functions import import_conf
 
 logger = logging.getLogger(__name__)
 
 # Maximum difference in size between left and right context.
 MAX_DIFF = 1
+
+PARTITIONS = int(import_conf("FastNgramPartitions"))
 
 
 class ContextMap:
@@ -150,7 +153,7 @@ def _find_contexts(acronym: str, min_freq: int) -> 'List[topic_list.Acronym]':
     :param min_freq:
     :return:
     """
-    model = resource_factory.get_center_map(functions.partition(acronym))
+    model = resource_factory.get_center_map(functions.partition(acronym, PARTITIONS))
 
     all_contexts = []  # type: List[topic_list.Acronym]
     for out_freq, contexts in model.contexts(acronym).items():
@@ -182,7 +185,7 @@ def _center_provider(contexts: 'List[topic_list.Acronym]', min_freq: int,
 
     rank = 0
     for contextualized_acronym in contexts:
-        partition = functions.partition(contextualized_acronym.acronym)
+        partition = functions.partition(contextualized_acronym.acronym, PARTITIONS)
         model = resource_factory.get_context_map(partition)
 
         left = contextualized_acronym.left_context
@@ -217,7 +220,7 @@ def create_map(ngrams: Dict[str, int], model: Union[ContextMap, CenterMap],
 
     for ngram, freq in sorted_ngrams:
         for context in _generate_ngram_contexts(ngram):
-            if functions.partition(context.acronym) == partition:
+            if functions.partition(context.acronym, PARTITIONS) == partition:
                 model.add(context.acronym, context.left_context, context.right_context, freq)
 
     logger.info("Fastngram model created.")

--- a/acres/util/functions.py
+++ b/acres/util/functions.py
@@ -234,7 +234,7 @@ def corpus_to_ngram_list(corpus: str, min_num_tokens: int,
     return dict_to_sorted_list(stats)
 
 
-def partition(word: str, partitions: int = 5) -> int:
+def partition(word: str, partitions: int) -> int:
     """
     Find a bucket for a given word.
 

--- a/acres/util/functions.py
+++ b/acres/util/functions.py
@@ -234,7 +234,7 @@ def corpus_to_ngram_list(corpus: str, min_num_tokens: int,
     return dict_to_sorted_list(stats)
 
 
-def partition(word: str, partitions: int = 4) -> int:
+def partition(word: str, partitions: int = 5) -> int:
     """
     Find a bucket for a given word.
 
@@ -245,12 +245,12 @@ def partition(word: str, partitions: int = 4) -> int:
     a = ord('a')
     z = ord('z')
     value = ord(word[0].lower())
-    if a <= value <= z:
+    if partitions > 1 and a <= value <= z:
         pos = value - a
-        return int(pos * partitions / (z - a + 1))
+        return int(pos * (partitions - 1) / (z - a + 1)) + 1
 
     # Catch-all for numbers, symbols and diacritics.
-    return 99
+    return 0
 
 
 def sample(iterable: Iterable, chance: float) -> Iterable:

--- a/config.ini.default
+++ b/config.ini.default
@@ -6,6 +6,10 @@ MORPH_GER = tests/resources/lex.xml
 # Free trial at https://azure.microsoft.com/en-us/try/cognitive-services/?api=bing-web-search-api
 BingSearchApiKey = %(BING_SEARCH_API_KEY)s
 
+# Number of partitions to split the fastNgram maps into.
+# A higher number of partitions is recommended for low-memory scenarios (e.g. 5 for 8 GB RAM).
+FastNgramPartitions = 5
+
 [proxy]
 UseProxy = no
 ProxyUser = DOMAIN\username

--- a/tests/util/test_functions.py
+++ b/tests/util/test_functions.py
@@ -68,17 +68,21 @@ def test_robust_text_import_from_dir():
 
 
 def test__partition():
-    assert functions.partition('a') == 0
-    assert functions.partition('g') == 0
-    assert functions.partition('h') == 1
-    assert functions.partition('m') == 1
-    assert functions.partition('n') == 2
-    assert functions.partition('t') == 2
-    assert functions.partition('u') == 3
-    assert functions.partition('z') == 3
-    assert functions.partition('0') == 99
-    assert functions.partition('9') == 99
-    assert functions.partition('ö') == 99
+    assert functions.partition('a', 5) == 1
+    assert functions.partition('g', 5) == 1
+    assert functions.partition('h', 5) == 2
+    assert functions.partition('m', 5) == 2
+    assert functions.partition('n', 5) == 3
+    assert functions.partition('t', 5) == 3
+    assert functions.partition('u', 5) == 4
+    assert functions.partition('z', 5) == 4
+    assert functions.partition('0', 5) == 0
+    assert functions.partition('9', 5) == 0
+    assert functions.partition('ö', 5) == 0
+
+    assert functions.partition('a', 1) == 0
+    assert functions.partition('z', 1) == 0
+    assert functions.partition('9', 1) == 0
 
 
 def test_sample():


### PR DESCRIPTION
This improves performance on high memory scenarios by using a single partition loaded only once.