### PR TITLE
Try to fix build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,8 +9,8 @@ matplotlib
 
 # dev
 pylint
-pytest>=3.7.3   # https://github.com/pytest-dev/pytest/issues/3819
 pytest-cov
+pytest>=3.7.3   # https://github.com/pytest-dev/pytest/issues/3819
 python-coveralls
 mypy
 sphinx

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,8 +9,8 @@ matplotlib
 
 # dev
 pylint
+pytest>=4.6   # Required by newer versions of pytest-cov
 pytest-cov
-pytest>=3.7.3   # https://github.com/pytest-dev/pytest/issues/3819
 python-coveralls
 mypy
 sphinx


### PR DESCRIPTION
`pytest-cov` now requires `pytest>=4.6` (https://github.com/pytest-dev/pytest-cov/commit/1689c9ad514e86ba9331e36b2ab84ddcac481a44), but somehow Travis is pulling `pytest==4.3.1` for Python 3.7 builds. 

Try to fix that by requiring first `pytest-cov`, which should pull the correct version of `pytest`.