### PR TITLE
Drop support for Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 matrix:
   include:
-    - python: "3.5"
     - python: "3.6"
     - python: "3.7"
     - python: "3.8"


### PR DESCRIPTION
Python 3.5 has reached EOL, so it's time to drop support for it and use Python 3.6+ exclusive features, like variable annotations.