### PR TITLE
Pin package versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ html2text==2019.8.11
 python-Levenshtein==0.12.0
 
 # jupyter notebooks
-scikit-learn==0.21.3
+scikit-learn==0.24.2
 matplotlib==3.1.1
 
 # dev

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
-gensim
-requests
-html2text
-python-Levenshtein
+gensim==3.8.0
+requests==2.22.0
+html2text==2019.8.11
+python-Levenshtein==0.12.0
 
 # jupyter notebooks
-scikit-learn
-matplotlib
+scikit-learn==0.21.3
+matplotlib==3.1.1
 
 # dev
 pylint


### PR DESCRIPTION
Pin dependency versions so that we can have reproducible builds.

This fixes the build by avoid installing the latest version of `gensim`, which has a different syntax for training models.